### PR TITLE
COBRA-3778 - disable delivery reports removes memory leak…

### DIFF
--- a/events/producer.go
+++ b/events/producer.go
@@ -47,6 +47,7 @@ func CreateProducer(kafkaAddrs []string, kafkaGroup string) *kafka.Producer {
 		"bootstrap.servers":  strings.Join(kafkaAddrs, ","),
 		"group.id":           kafkaGroup,
 		"session.timeout.ms": 6000,
+		"go.delivery.reports": false,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
See issue https://github.com/confluentinc/confluent-kafka-go/issues/341